### PR TITLE
set CMAKE_INSTALL_PREFIX to /usr

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sudo apt-get install python-scipy
 cd gr-j2497
 mkdir build
 cd build
-cmake ..
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
 make
 sudo make install
 sudo ldconfig


### PR DESCRIPTION
avoids module import error for j2497 in grc on the instant-gnuradio images